### PR TITLE
[GST-2195] Verified working with Ansible 2.1.1 and 1.9.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ hash_behaviour = merge
 
 ## Installation and Dependencies
 
-This role has no dependencies.
+This role has no dependencies and has been tested with Ansible 1.9.4 and 2.2.1.
 
 To install run `ansible-galaxy install sansible.java` or add this to your
 `roles.yml`


### PR DESCRIPTION
This repository has been tested with Ansible 1.9.4 and 2.1.1 and found to be working without code changes. The README.md has been amended to reflect this.
