### PR TITLE
[GST-2195] Correct meta data to make it work with current Ansible Galaxy

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -8,6 +8,9 @@ galaxy_info:
   description: Oracle Java installation role
   license: MIT
   min_ansible_version: 1.8
-  platforms: [ ubuntu ]
+  platforms:
+    - name: Ubuntu
+      versions:
+        - all
   categories:
     - development


### PR DESCRIPTION
This should resolve the "The platform 'ubuntu' does not appear to be a dictionary, skipping" error encountered in Ansible Galaxy.
