### PR TITLE
[GITHUB-7] Ensures Java CA certs for OpenJDK

### DIFF
--- a/tasks/build/build-openjdk.yml
+++ b/tasks/build/build-openjdk.yml
@@ -27,3 +27,15 @@
     name: java
     path: "{{ jdk_path.stdout }}/jre/bin/java"
   when: java.set_as_default
+
+- name: Ensure Java CA certs installed
+  become: yes
+  apt:
+    name: ca-certificates-java
+    state: present
+
+- name: Ensure Java CA cert exists
+  become: yes
+  command: update-ca-certificates -f
+  args:
+    creates: /etc/ssl/certs/java/cacerts


### PR DESCRIPTION
These certs are missing on EC2 instances by default so we need
to ensure that they exist.