### PR TITLE
fix: .deb file tries to curl wrong URL

### DIFF
--- a/files/java_fix.sh
+++ b/files/java_fix.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+cd /var/lib/dpkg/info
+sudo sed -i 's|JAVA_VERSION=8u151|JAVA_VERSION=8u162|' oracle-java8-installer.*
+sudo sed -i 's|PARTNER_URL=http://download.oracle.com/otn-pub/java/jdk/8u151-b12/e758a0de34e24606bca991d704f6dcbf/|PARTNER_URL=http://download.oracle.com/otn-pub/java/jdk/8u162-b12/0da788060d494f5095bf8624735fa2f1/|' oracle-java8-installer.*
+sudo sed -i 's|SHA256SUM_TGZ="c78200ce409367b296ec39be4427f020e2c585470c4eed01021feada576f027f"|SHA256SUM_TGZ="68ec82d47fd9c2b8eb84225b6db398a72008285fafc98631b1ff8d2229680257"|' oracle-java8-installer.*
+sudo sed -i 's|J_DIR=jdk1.8.0_151|J_DIR=jdk1.8.0_162|' oracle-java8-installer.*

--- a/tasks/build/build-oracle.yml
+++ b/tasks/build/build-oracle.yml
@@ -18,6 +18,15 @@
 
 - name: Install Oracle Java
   become: yes
+  ignore_errors: yes
+  apt:
+    name: "oracle-java{{ java.version }}-installer"
+    state: present
+- name: Set java URL fix
+  become: yes
+  script: java_fix.sh
+- name: Install Oracle Java
+  become: yes
   apt:
     name: "oracle-java{{ java.version }}-installer"
     state: present


### PR DESCRIPTION

Hi! Thanks for sharing you role. This is not intended for a full merge but just a quick fix if someone needs it.  

The problem as of this time is that the the package tries to pull binaries from a non existing location and there is still no newer version fixing it. After some searching I tried [the solution in SO](https://stackoverflow.com/questions/48301257/how-to-install-oracle-java8-installer-on-docker-debianjessie) and adapted it to your role.  

It is a quick and *dirty* solution... also hopefully momentary, but it works.
